### PR TITLE
Update rustls dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ webpki-roots-certs      = ["webpki-roots"]
 
 [dependencies]
 log    = "^0.4"
-rustls = "^0.20"
-webpki = "^0.22"
+rustls = "^0.21"
+rustls-webpki = "^0.100"
 
 [dependencies.rustls-native-certs]
 version  = "^0.6"


### PR DESCRIPTION
Hi!
This PR updates rustls to its latest release and exports rustls-webpki (now used and actively maintained by rustls) instead of webpki.