### PR TITLE
rustls: do not depend on unnecessary features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name          = "rustls-connector"
-version       = "0.20.0"
+version       = "0.21.0"
 authors       = ["Marc-Antoine Perennou <Marc-Antoine@Perennou.com>"]
 edition       = "2021"
 description   = "Connector similar to openssl or native-tls for rustls"
@@ -15,12 +15,17 @@ rust-version  = "1.60.0"
 name = "rustls_connector"
 
 [features]
-default            = ["native-certs"]
+default            = ["native-certs", "rustls--aws_lc_rs" ]
 native-certs       = ["rustls-native-certs", "log"]
 webpki-roots-certs = ["webpki-roots"]
 
+# rustls crypto providers. Choose at least one. Otherwise, runtime errors.
+# See https://docs.rs/rustls/latest/rustls/#crate-features. for more info
+rustls--aws_lc_rs = ["rustls/aws_lc_rs"] # default, but doesn't build everywhere
+rustls--ring = ["rustls/ring"] # more compatible, (e.g., easily builds on Windows)
+
 [dependencies]
-rustls = "^0.23"
+rustls = { version = "^0.23", default-features = false, features = ["std"] }
 rustls-webpki = "^0.102"
 
 [dependencies.log]


### PR DESCRIPTION
The main motivation for that change is to prevent an unnecessary dependency to rustls/aws_lc_rs [0]. aws_lc_rs has a non-default build with external tools (cmake, nasm) which breaks CI in consumer projects, such as ttfb [1].

I'm not sure what's the best solution here:
- a) select the crypt provider (rustls crate feature) as a feature in this crate
- b) do not have a crypt provider in this crate; users may manually have to add `rustls` as dependency and specify the corresponding dep

I think b) is fine.

[0] : https://docs.rs/rustls/latest/rustls/#crate-features
[1] : https://github.com/phip1611/ttfb/