### PR TITLE
Don't return an error in new_with_native_certs due to partial certificate loading failures

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,9 +76,14 @@ impl RustlsConnectorConfig {
     /// Returns an error if we fail to load the native certs.
     pub fn new_with_native_certs() -> io::Result<Self> {
         let mut root_store = RootCertStore::empty();
-        let mut certs_result = rustls_native_certs::load_native_certs();
-        if let Some(err) = certs_result.errors.pop() {
-            return Err(io::Error::other(err));
+        let certs_result = rustls_native_certs::load_native_certs();
+        for err in certs_result.errors {
+            log::warn!("Got error while loading some native certificates: {err:?}");
+        }
+        if certs_result.certs.is_empty() {
+            return Err(io::Error::other(
+                "Could not load any valid native certificates",
+            ));
         }
         for cert in certs_result.certs {
             if let Err(err) = root_store.add(cert) {


### PR DESCRIPTION
Ref. https://github.com/amqp-rs/rustls-connector/issues/9

Tested the change with lapin 4.4.0 and it seemed to resolve the issue of failing with unreadable certs. Now just produces the following warning logs.

```
Got error while loading some native certificates: Error { context: \"failed to read PEM from file\", kind: Io { inner: Os { code: 13, kind: PermissionDenied, message: \"Permission denied\" }, path: \"/etc/ssl/certs/some-cert.crt\" } }
```

I figured it should still produce an error if no readable certs are found at all.